### PR TITLE
Fix Boss 2 - InspectorGadget_AS.asl

### DIFF
--- a/InspectorGadget_AS.asl
+++ b/InspectorGadget_AS.asl
@@ -176,7 +176,20 @@ update {
         }
     }
     //Reset BossState to false
-    if (vars.watchers["currentStage"].Changed) vars.InBoss3_5 = false;
+    if (vars.watchers["currentStage"].Changed)
+    {
+        vars.InBoss3_5 = false;
+    }
+    vars.isAlive = vars.watchers["deathreason"].Current == 0;
+    
+    //If the player dies in Stage 2,reset boss state to Phase 1
+    if (vars.isAlive == false && vars.watchers["currentStage"].Current == 2)
+    {
+        vars.Boss2Axe = true;
+        vars.Boss2Phase2 = false;
+        vars.isAlive = true;
+        vars.resetFight = false;
+    }
 }
 
 start {


### PR DESCRIPTION
Re-fixed boss 2 : Error that made the timer split when dying on Boss 2 then without resetting trying the boss again.

Fix : Added lines to reset the state of the boss if you die during phase 2